### PR TITLE
feat: refresh background and add animations

### DIFF
--- a/script.js
+++ b/script.js
@@ -47,6 +47,7 @@ const observer = new IntersectionObserver(
         if (activeLink) {
           activeLink.classList.add('active');
         }
+        entry.target.classList.add('visible');
       }
     });
   },

--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@ body {
   margin: 0;
   font-family: "Poppins", sans-serif;
   background-color: var(--color-bg);
-  background-image: url("https://images.unsplash.com/photo-1462331940025-496dfbfc7564?auto=format&fit=crop&w=1350&q=80");
+  background-image: url("https://images.unsplash.com/photo-1496307042754-b4aa456c4a2d?auto=format&fit=crop&w=1350&q=80");
   background-repeat: no-repeat;
   background-size: cover;
   background-attachment: fixed;
@@ -49,12 +49,12 @@ a:hover {
   background-image:
     linear-gradient(
       -45deg,
-      rgba(30, 58, 138, 0.8),
-      rgba(37, 99, 235, 0.8),
-      rgba(59, 130, 246, 0.8),
-      rgba(29, 78, 216, 0.8)
+      rgba(109, 40, 217, 0.8),
+      rgba(147, 51, 234, 0.8),
+      rgba(236, 72, 153, 0.8),
+      rgba(244, 63, 94, 0.8)
     ),
-    url("https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1350&q=80");
+    url("https://images.unsplash.com/photo-1517694712202-14dd9538aa97?auto=format&fit=crop&w=1350&q=80");
   background-size:
     400% 400%,
     cover;
@@ -63,7 +63,7 @@ a:hover {
     center;
   background-repeat: no-repeat;
   background-attachment: fixed;
-  animation: gradient 15s ease infinite;
+  animation: gradient 20s ease infinite;
 }
 
 .profile-photo {
@@ -73,6 +73,7 @@ a:hover {
   object-fit: cover;
   border: 4px solid var(--color-accent);
   margin-bottom: 20px;
+  animation: float 6s ease-in-out infinite;
 }
 
 @keyframes gradient {
@@ -84,6 +85,16 @@ a:hover {
   }
   100% {
     background-position: 0% 50%;
+  }
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
   }
 }
 
@@ -344,6 +355,17 @@ footer {
 
 .back-to-top:hover {
   background: var(--color-primary);
+}
+
+section {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+}
+
+section.visible {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 body.dark-mode {


### PR DESCRIPTION
## Summary
- use a new hero backdrop and site background image
- animate the profile photo and section reveals for a livelier feel
- highlight active sections while scrolling

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b2d5cfb483308f42920f52791ead