### PR TITLE
Fix mobile menu positioning and anchor offset

### DIFF
--- a/slick_personal_website2.html
+++ b/slick_personal_website2.html
@@ -61,6 +61,10 @@
             padding: 0 20px;
         }
 
+        section {
+            scroll-margin-top: 80px;
+        }
+
         /* Header */
         header {
             position: fixed;
@@ -484,7 +488,8 @@
             nav { position: relative; }
             .nav-links {
                 position: absolute;
-                top: 60px;
+                top: 100%;
+                left: 0;
                 right: 0;
                 background: rgba(10, 10, 10, 0.95);
                 flex-direction: column;
@@ -494,6 +499,7 @@
                 overflow: hidden;
                 padding: 0 0 1rem 0;
                 transition: max-height 0.3s ease;
+                z-index: 1000;
             }
             .nav-links.open { max-height: 300px; }
             .nav-links li { text-align: center; }


### PR DESCRIPTION
## Summary
- ensure mobile navigation drops below header and spans full width
- add scroll-margin to sections so anchors aren't hidden beneath the fixed header

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68af872886c08330985d2f6e40fe4344