### PR TITLE
Improve mobile layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,6 +22,20 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+
+  const mobileNavLinks = document.querySelectorAll('.navbar a');
+  mobileNavLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      const navbar = document.querySelector('.navbar');
+      const toggleBtn = document.querySelector('.menu-toggle');
+      if (navbar && navbar.classList.contains('open')) {
+        navbar.classList.remove('open');
+        if (toggleBtn) {
+          toggleBtn.setAttribute('aria-expanded', 'false');
+        }
+      }
+    });
+  });
 });
 
 function toggleTheme() {

--- a/style.css
+++ b/style.css
@@ -399,6 +399,10 @@ body.dark-mode {
 
 /* Responsive */
 @media (max-width: 768px) {
+  body,
+  .hero {
+    background-attachment: scroll;
+  }
   .hero h1 {
     font-size: 36px;
   }
@@ -417,6 +421,11 @@ body.dark-mode {
   }
   .navbar ul li {
     margin: 10px 0;
+    width: 100%;
+  }
+  .navbar ul li a {
+    width: 100%;
+    justify-content: center;
   }
   .navbar.open ul {
     display: flex;


### PR DESCRIPTION
## Summary
- Ensure mobile backgrounds scroll naturally instead of fixed
- Make navbar links full-width on small screens for better tap targets
- Close the mobile menu when navigation links are selected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af88a334388330a6064d16405fa55c