### PR TITLE
Improve mobile layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,6 +22,20 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+
+  const mobileNavLinks = document.querySelectorAll('.navbar a');
+  mobileNavLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      const navbar = document.querySelector('.navbar');
+      const toggleBtn = document.querySelector('.menu-toggle');
+      if (navbar && navbar.classList.contains('open')) {
+        navbar.classList.remove('open');
+        if (toggleBtn) {
+          toggleBtn.setAttribute('aria-expanded', 'false');
+        }
+      }
+    });
+  });
 });
 
 function toggleTheme() {

--- a/slick_personal_website2.html
+++ b/slick_personal_website2.html
@@ -493,15 +493,19 @@
                 right: 0;
                 background: rgba(10, 10, 10, 0.95);
                 flex-direction: column;
-                gap: 1rem;
                 width: 100%;
                 max-height: 0;
                 overflow: hidden;
-                padding: 0 0 1rem 0;
-                transition: max-height 0.3s ease;
+                padding: 0;
+                gap: 0;
+                transition: max-height 0.3s ease, padding 0.3s ease;
                 z-index: 1000;
             }
-            .nav-links.open { max-height: 300px; }
+            .nav-links.open {
+                max-height: 300px;
+                padding: 1rem 0;
+                gap: 1rem;
+            }
             .nav-links li { text-align: center; }
             .about-content { grid-template-columns: 1fr; }
             .skills-grid { grid-template-columns: repeat(2, 1fr); }

--- a/style.css
+++ b/style.css
@@ -399,6 +399,10 @@ body.dark-mode {
 
 /* Responsive */
 @media (max-width: 768px) {
+  body,
+  .hero {
+    background-attachment: scroll;
+  }
   .hero h1 {
     font-size: 36px;
   }
@@ -417,6 +421,11 @@ body.dark-mode {
   }
   .navbar ul li {
     margin: 10px 0;
+    width: 100%;
+  }
+  .navbar ul li a {
+    width: 100%;
+    justify-content: center;
   }
   .navbar.open ul {
     display: flex;


### PR DESCRIPTION
## Summary
- Ensure mobile backgrounds scroll naturally instead of fixed
- Make navbar links full-width on small screens for better tap targets
- Close the mobile menu when navigation links are selected
- Prevent residual spacing so the hamburger menu fully collapses on iPhone

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af88a334388330a6064d16405fa55c