### PR TITLE
fix: close mobile menu when clicking outside

### DIFF
--- a/script.js
+++ b/script.js
@@ -36,6 +36,20 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
+
+  document.addEventListener('click', e => {
+    const navbar = document.querySelector('.navbar');
+    const toggleBtn = document.querySelector('.menu-toggle');
+    if (
+      navbar &&
+      toggleBtn &&
+      navbar.classList.contains('open') &&
+      !navbar.contains(e.target)
+    ) {
+      navbar.classList.remove('open');
+      toggleBtn.setAttribute('aria-expanded', 'false');
+    }
+  });
 });
 
 function toggleTheme() {


### PR DESCRIPTION
## Summary
- ensure mobile navigation closes when tapping outside the menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af8bb6d9a08330b6ad2ce1dd643208